### PR TITLE
Multifile

### DIFF
--- a/hjass.cabal
+++ b/hjass.cabal
@@ -27,7 +27,9 @@ library
                    llvm-general == 3.4.4.3,
                    llvm-general-pure == 3.4.4.1,
                    safe >=0.3 && <0.4,
-                   containers >= 0.4.2.1
+                   containers >= 0.4.2.1,
+                   directory,
+                   filepath >=1.3 && <1.4
   ghc-options:       -Wall
   default-language:  Haskell2010
   hs-source-dirs:    src/library
@@ -59,7 +61,9 @@ test-suite all-tests
                   tasty-hunit,
                   HUnit,
                   tasty-quickcheck,
-                  QuickCheck
+                  QuickCheck,
+                  directory,
+                  filepath >=1.3 && <1.4
                   
   default-language:  Haskell2010                
   other-modules:   

--- a/hjass.cabal
+++ b/hjass.cabal
@@ -29,19 +29,56 @@ library
                    safe >=0.3 && <0.4,
                    containers >= 0.4.2.1,
                    directory,
-                   filepath >=1.3 && <1.4
+                   filepath >=1.3 && <1.4,
+                   system-fileio >=0.3 && <0.4
   ghc-options:       -Wall
   default-language:  Haskell2010
   hs-source-dirs:    src/library
-  exposed-modules:   Language.Jass.Parser.Grammar
-  other-modules:   
-                   Language.Jass.Parser.AST.FunctionDecl,
-                   Language.Jass.Parser.AST.LocalVar,
-                   Language.Jass.Parser.AST.Expression,
-                   Language.Jass.Parser.AST.Statement
+  exposed-modules:   
+                     Language.Jass.Codegen.Context,
+                     Language.Jass.Codegen.Expression,
+                     Language.Jass.Codegen.Generator,
+                     Language.Jass.Codegen.Helpers,
+                     Language.Jass.Codegen.Native,
+                     Language.Jass.Codegen.Statement,
+                     Language.Jass.Codegen.Type,
+                     Language.Jass.JIT.Calling,
+                     Language.Jass.JIT.Executing,
+                     Language.Jass.JIT.Module,
+                     Language.Jass.JassType,
+                     Language.Jass.Parser.AST,
+                     Language.Jass.Parser.AST.Expression,
+                     Language.Jass.Parser.AST.Function,
+                     Language.Jass.Parser.AST.FunctionDecl,
+                     Language.Jass.Parser.AST.GlobalVar,
+                     Language.Jass.Parser.AST.Import,
+                     Language.Jass.Parser.AST.JassModule,
+                     Language.Jass.Parser.AST.LocalVar,
+                     Language.Jass.Parser.AST.NativeDecl,
+                     Language.Jass.Parser.AST.Parameter,
+                     Language.Jass.Parser.AST.Statement,
+                     Language.Jass.Parser.AST.TypeDef,
+                     Language.Jass.Parser.Grammar,
+                     Language.Jass.Parser.Lexer,
+                     Language.Jass.Parser.SourcePos,
+                     Language.Jass.Program,
+                     Language.Jass.Runtime.Code,
+                     Language.Jass.Runtime.Globals,
+                     Language.Jass.Runtime.Memory,
+                     Language.Jass.Runtime.Natives,
+                     Language.Jass.Runtime.String,
+                     Language.Jass.Semantic.Callable,
+                     Language.Jass.Semantic.Check,
+                     Language.Jass.Semantic.Context,
+                     Language.Jass.Semantic.SemanticError,
+                     Language.Jass.Semantic.Type,
+                     Language.Jass.Semantic.Variable,
+                     Language.Jass.ShowIndent,
+                     Language.Jass.Utils
 
 test-suite all-tests
   type:            exitcode-stdio-1.0
+  other-modules:   Language.Jass.Parser.AST.Statement
   main-is:         all-tests.hs
   ghc-options:     -Wall -rtsopts
   build-depends:   
@@ -63,36 +100,11 @@ test-suite all-tests
                   tasty-quickcheck,
                   QuickCheck,
                   directory,
-                  filepath >=1.3 && <1.4
+                  filepath >=1.3 && <1.4,
+                  system-fileio >=0.3 && <0.4
                   
   default-language:  Haskell2010                
-  other-modules:   
-                  Language.Jass.Codegen.Context,
-                  Language.Jass.Codegen.Generator,
-                  Language.Jass.Codegen.GeneratorTest,
-                  Language.Jass.JassType,
-                  Language.Jass.Parser.AST,
-                  Language.Jass.Parser.AST.Expression,
-                  Language.Jass.Parser.AST.Function,
-                  Language.Jass.Parser.AST.FunctionDecl,
-                  Language.Jass.Parser.AST.GlobalVar,
-                  Language.Jass.Parser.AST.JassModule,
-                  Language.Jass.Parser.AST.LocalVar,
-                  Language.Jass.Parser.AST.NativeDecl,
-                  Language.Jass.Parser.AST.Parameter,
-                  Language.Jass.Parser.AST.Statement,
-                  Language.Jass.Parser.AST.TypeDef,
-                  Language.Jass.Parser.ASTTest,
-                  Language.Jass.Parser.Grammar,
-                  Language.Jass.Parser.GrammarTest,
-                  Language.Jass.Semantic.Callable,
-                  Language.Jass.Semantic.Check,
-                  Language.Jass.Semantic.CheckTest,
-                  Language.Jass.Semantic.Context,
-                  Language.Jass.Semantic.SemanticError,
-                  Language.Jass.Semantic.Type,
-                  Language.Jass.Semantic.Variable,
-                  Language.Jass.ShowIndent
+  other-modules:  
   hs-source-dirs:  
                   src/library,
                   test-suites

--- a/src/library/Language/Jass/JIT/Module.hs
+++ b/src/library/Language/Jass/JIT/Module.hs
@@ -1,7 +1,7 @@
 module Language.Jass.JIT.Module(
     ExtractAST(..)
-  , ParsedModule(..)
-  , UnlinkedModule(..)
+  , JassProgram(..)
+  , UnlinkedProgram(..)
   , JITModule(..)
   , nativesMapFromMapping
   , isAllNativesBinded
@@ -23,9 +23,9 @@ import Data.Either
 import Data.List (nub)
 
 -- | Compiled module with unset natives
-data ParsedModule = ParsedModule NativesMapping TypesMap LLVMAST.Module
+data JassProgram = JassProgram NativesMapping TypesMap LLVMAST.Module
 -- | Raised into llvm module
-data UnlinkedModule = UnlinkedModule NativesMap TypesMap LLVM.Module
+data UnlinkedProgram = UnlinkedProgram NativesMap TypesMap LLVM.Module
 -- | Executing module
 data JITModule = JITModule TypesMap (ExecutableModule JIT)
 
@@ -34,11 +34,11 @@ type NativesMap = HashMap String (Either LLVMAST.Name (LLVMAST.Name, FunPtr ()))
 class ExtractAST a where
   extractAST :: a -> IO LLVMAST.Module
 
-instance ExtractAST ParsedModule where
-  extractAST (ParsedModule _ _ m) = return m
+instance ExtractAST JassProgram where
+  extractAST (JassProgram _ _ m) = return m
   
-instance ExtractAST UnlinkedModule where
-  extractAST (UnlinkedModule _ _ m) = moduleAST m
+instance ExtractAST UnlinkedProgram where
+  extractAST (UnlinkedProgram _ _ m) = moduleAST m
  
 -- | Creates new native map from mapping (user should fill all natives with ptrs)
 nativesMapFromMapping :: NativesMapping -> NativesMap

--- a/src/library/Language/Jass/Parser/AST.hs
+++ b/src/library/Language/Jass/Parser/AST.hs
@@ -5,6 +5,7 @@ module Language.Jass.Parser.AST(
 import Language.Jass.JassType as ReExports
 import Language.Jass.Parser.SourcePos as ReExports
 import Language.Jass.Parser.AST.JassModule as ReExports
+import Language.Jass.Parser.AST.Import as ReExports
 import Language.Jass.Parser.AST.TypeDef as ReExports
 import Language.Jass.Parser.AST.GlobalVar as ReExports
 import Language.Jass.Parser.AST.LocalVar as ReExports

--- a/src/library/Language/Jass/Parser/AST/Import.hs
+++ b/src/library/Language/Jass/Parser/AST/Import.hs
@@ -1,0 +1,20 @@
+module Language.Jass.Parser.AST.Import(
+  Import(..)
+  ) where
+  
+import Language.Jass.Parser.SourcePos
+import Language.Jass.ShowIndent
+
+data Import = Import {
+  importSourcePos :: SrcPos,
+  importModuleName :: String 
+}
+
+instance Show Import where
+  show = showIndent 0 
+  
+instance ShowIndent Import where
+  showIndent i import' = makeIndent i ++ "import " ++ importModuleName import'
+  
+instance Eq Import where
+  (Import _ m1) == (Import _ m2) = m1 == m2

--- a/src/library/Language/Jass/Parser/AST/JassModule.hs
+++ b/src/library/Language/Jass/Parser/AST/JassModule.hs
@@ -8,15 +8,17 @@ import Language.Jass.Parser.AST.TypeDef
 import Language.Jass.Parser.AST.GlobalVar
 import Language.Jass.Parser.AST.NativeDecl
 import Language.Jass.Parser.AST.Function
+import Language.Jass.Parser.AST.Import
 
 -- Global declarations
-data JassModule = JassModule SrcPos [TypeDef] [GlobalVar] [NativeDecl] [Function]
+data JassModule = JassModule SrcPos [Import] [TypeDef] [GlobalVar] [NativeDecl] [Function]
     
 instance Show JassModule where
   show = showIndent 0
   
 instance ShowIndent JassModule where
-  showIndent i (JassModule _ typedefs globals natives functions) = 
+  showIndent i (JassModule _ imports typedefs globals natives functions) =
+      newlineSep (map (showIndent i) imports) ++ "\n" ++ 
       newlineSep (map (showIndent i) typedefs) ++ "\n" ++
       globalsString ++
       newlineSep (map (showIndent i) natives) ++ "\n" ++
@@ -24,5 +26,5 @@ instance ShowIndent JassModule where
       where globalsString = if null globals then "" else  "globals\n" ++ newlineSep (map (showIndent (i+1)) globals) ++ "\n" ++ makeIndent i ++ "endglobals\n"
 
 instance Eq JassModule where
-  (JassModule _ defs1 globals1 natives1 funcs1) == (JassModule _ defs2 globals2 natives2 funcs2) =
-    defs1 == defs2 && globals1 == globals2 && natives1 == natives2 && funcs1 == funcs2
+  (JassModule _ imports1 defs1 globals1 natives1 funcs1) == (JassModule _ imports2 defs2 globals2 natives2 funcs2) =
+    imports1 == imports2 && defs1 == defs2 && globals1 == globals2 && natives1 == natives2 && funcs1 == funcs2

--- a/src/library/Language/Jass/Parser/Lexer.hs
+++ b/src/library/Language/Jass/Parser/Lexer.hs
@@ -32,7 +32,7 @@ lexer = Tok.makeTokenParser style
        , "mod", "and", "or", "not", "native", "returns", "take", "globals", "endglobals"
        , "nothing", "native", "endfunction", "local", "array"
        , "set", "call", "if", "then", "endif", "elseif", "else"
-       , "loop", "endloop", "exitwhen", "return", "debug"]
+       , "loop", "endloop", "exitwhen", "return", "debug", "import"]
     --lexeme = Tok.lexeme emptyDef
     style = emptyDef {
       Tok.commentLine = "//",

--- a/src/library/Language/Jass/Program.hs
+++ b/src/library/Language/Jass/Program.hs
@@ -1,21 +1,32 @@
 module Language.Jass.Program(
     makeEmptyNativeTable
-  , JassProgram(..)
+  , JassProgram
+  , JITModule
+  , NativeTableMaker
   , constructProgram
   , constructProgramFromSource
   , executeProgram
+  , module ReExport
   ) where
 
 import qualified Data.HashMap.Strict as HM
 import Language.Jass.JIT.Executing
 import Language.Jass.JIT.Module
+import Language.Jass.JIT.Calling as ReExport
+import Language.Jass.Parser.Grammar
+import Language.Jass.Semantic.Check
+import Language.Jass.Codegen.Generator
+import Language.Jass.Utils
+import LLVM.General.Context
+import Control.Applicative
 import Control.Monad.Trans.Except
 import Control.Monad.IO.Class
 import Control.Monad
 import System.Directory
 import System.FilePath
-
-data JassProgram
+import qualified Data.Traversable as T
+import Filesystem (isFile)
+import Data.String
 
 -- | Helper to generate programs without natives
 makeEmptyNativeTable :: NativeTableMaker
@@ -25,32 +36,40 @@ makeEmptyNativeTable _ = return []
 constructProgram :: 
   HM.HashMap String String -- ^ List of (module name, source code)
   -> String -- ^ Name of main module
-  -> NativeTableMaker -- ^ User natives
   -> ExceptT String IO JassProgram -- ^ Parsed and checked jass program
-constructProgram = undefined
-
+constructProgram imports mainModuleName = do
+  parsedImports <- T.sequence $ HM.mapWithKey (\k v -> liftExceptPure $ parseJass k v) imports
+  case HM.lookup mainModuleName parsedImports of
+    Nothing -> throwE $ "Cannot find main module with name: " ++ mainModuleName
+    Just mainModule -> do
+      context <- liftExceptPure $ checkModuleSemantic parsedImports mainModule
+      uncurry3 JassProgram <$> liftExceptPure (uncurry3 (generateLLVM mainModuleName) context)
+      
 -- | Creates jass program from set of modules stored in filesystem
 constructProgramFromSource ::
   FilePath -- ^ Path to folder
   -> FilePath -- ^ Relative path to main module
-  -> NativeTableMaker -- ^ User natives
   -> ExceptT String IO JassProgram -- ^ Parsed and checked jass program
-constructProgramFromSource folder mainPath nativeMaker = do
+constructProgramFromSource folder mainPath = do
   isMainExists <- liftIO $ doesFileExist fullMainPath
   unless isMainExists $ throwE $ "Cannot find main module at " ++ fullMainPath
-  fileList <- liftIO $ getDirectoryContents folder
-  fileSources <- liftIO $ mapM readFile fileList
+  fileList <- liftIO $ filterJassFiles folder =<< getDirectoryContents folder
+  fileSources <- liftIO $ mapM readFile $ fmap (\p -> folder ++ "/" ++ p) fileList
   let modulesMap = HM.fromList $ fmap makeModuleName fileList `zip` fileSources 
-  constructProgram modulesMap (makeModuleName mainPath) nativeMaker
+  constructProgram modulesMap $ makeModuleName mainPath
   where
     fullMainPath = folder ++ "/" ++ mainPath
-    
+
 executeProgram ::
   JassProgram -- ^ Loaded jass program
+  -> NativeTableMaker -- ^ User natives
   -> (JITModule -> ExceptT String IO a) -- ^ What to do while executing
   -> ExceptT String IO a -- ^ Result of execution
-executeProgram = undefined
- 
+executeProgram prog natives action = liftExcept $ withContext $ \cntx -> runExceptT $ 
+  withRaisedAST cntx prog $ \llvmModule -> do
+    optimizeModule llvmModule
+    withJassJIT cntx natives llvmModule action
+
 -- | some/path/to/module.j => some.path.to.module
 makeModuleName :: String -> String
 makeModuleName s = map replDots $ dropExtension s
@@ -58,3 +77,11 @@ makeModuleName s = map replDots $ dropExtension s
   replDots '/' = '.'
   replDots '\\' = '.'
   replDots c = c
+  
+-- | Removes non .j files
+filterJassFiles :: FilePath -> [FilePath] -> IO [FilePath]
+filterJassFiles folder = filterM cond
+  where 
+  cond nm =  do
+    isf <- isFile $ fromString $ folder ++ "/" ++ nm
+    return $ isf && takeExtension nm == ".j"

--- a/src/library/Language/Jass/Program.hs
+++ b/src/library/Language/Jass/Program.hs
@@ -1,0 +1,60 @@
+module Language.Jass.Program(
+    makeEmptyNativeTable
+  , JassProgram(..)
+  , constructProgram
+  , constructProgramFromSource
+  , executeProgram
+  ) where
+
+import qualified Data.HashMap.Strict as HM
+import Language.Jass.JIT.Executing
+import Language.Jass.JIT.Module
+import Control.Monad.Trans.Except
+import Control.Monad.IO.Class
+import Control.Monad
+import System.Directory
+import System.FilePath
+
+data JassProgram
+
+-- | Helper to generate programs without natives
+makeEmptyNativeTable :: NativeTableMaker
+makeEmptyNativeTable _ = return []
+
+-- | Creates jass program from set of modules
+constructProgram :: 
+  HM.HashMap String String -- ^ List of (module name, source code)
+  -> String -- ^ Name of main module
+  -> NativeTableMaker -- ^ User natives
+  -> ExceptT String IO JassProgram -- ^ Parsed and checked jass program
+constructProgram = undefined
+
+-- | Creates jass program from set of modules stored in filesystem
+constructProgramFromSource ::
+  FilePath -- ^ Path to folder
+  -> FilePath -- ^ Relative path to main module
+  -> NativeTableMaker -- ^ User natives
+  -> ExceptT String IO JassProgram -- ^ Parsed and checked jass program
+constructProgramFromSource folder mainPath nativeMaker = do
+  isMainExists <- liftIO $ doesFileExist fullMainPath
+  unless isMainExists $ throwE $ "Cannot find main module at " ++ fullMainPath
+  fileList <- liftIO $ getDirectoryContents folder
+  fileSources <- liftIO $ mapM readFile fileList
+  let modulesMap = HM.fromList $ fmap makeModuleName fileList `zip` fileSources 
+  constructProgram modulesMap (makeModuleName mainPath) nativeMaker
+  where
+    fullMainPath = folder ++ "/" ++ mainPath
+    
+executeProgram ::
+  JassProgram -- ^ Loaded jass program
+  -> (JITModule -> ExceptT String IO a) -- ^ What to do while executing
+  -> ExceptT String IO a -- ^ Result of execution
+executeProgram = undefined
+ 
+-- | some/path/to/module.j => some.path.to.module
+makeModuleName :: String -> String
+makeModuleName s = map replDots $ dropExtension s
+  where
+  replDots '/' = '.'
+  replDots '\\' = '.'
+  replDots c = c

--- a/test-suites/Language/Jass/Codegen/GeneratorTest.hs
+++ b/test-suites/Language/Jass/Codegen/GeneratorTest.hs
@@ -243,7 +243,7 @@ checkCode jit = do
     exec0 = callFunc0 jit
          
 simpleCodegenTest :: TestTree
-simpleCodegenTest = let dbgFlag = False in testGroup "jass helloworld"
+simpleCodegenTest = let dbgFlag = False in testGroup "jass codegeneration"
   [ testCase "hello.j" $ checkJassFile "tests/hello.j" dbgFlag makeNativeTable checkHello,
     testCase "math.j" $ checkJassFile "tests/math.j" dbgFlag makeEmptyNativeTable checkMath,
     testCase "global.j" $ checkJassFile "tests/global.j" dbgFlag makeEmptyNativeTable checkGlobal,

--- a/test-suites/Language/Jass/Codegen/MultiFileTest.hs
+++ b/test-suites/Language/Jass/Codegen/MultiFileTest.hs
@@ -1,0 +1,26 @@
+module Language.Jass.Codegen.MultiFileTest where
+
+import Language.Jass.Program
+import Language.Jass.JIT.Executing
+import Language.Jass.JIT.Module
+import Control.Monad.Trans.Except
+import Control.Monad
+
+import Test.Tasty
+import Test.Tasty.HUnit
+
+type NativeWriteln = CString -> IO ()
+nativeWriteln :: NativeWriteln
+nativeWriteln adr = putStrLn =<< fromJass adr
+foreign import ccall "wrapper" mkNativeWriteln :: NativeWriteln -> IO (FunPtr NativeWriteln)
+
+makeNativeTable :: NativeTableMaker
+makeNativeTable _ = liftIO $ sequence [("writeln",) . castFunPtr <$> mkNativeWriteln nativeWriteln]
+
+checkJassFolder :: FilePath -> NativeTableMaker -> Assertion
+checkJassFolder folder natives = return ()
+
+multifileTests :: TestTree
+multifileTests = let dbgFlag = False in testGroup "jass helloworld"
+  [ testCase "hello.j" $ checkJassFolder "tests/multifile" makeNativeTable
+  ]

--- a/test-suites/Language/Jass/Codegen/MultiFileTest.hs
+++ b/test-suites/Language/Jass/Codegen/MultiFileTest.hs
@@ -1,26 +1,38 @@
+{-# LANGUAGE TupleSections #-}
 module Language.Jass.Codegen.MultiFileTest where
 
 import Language.Jass.Program
-import Language.Jass.JIT.Executing
-import Language.Jass.JIT.Module
-import Control.Monad.Trans.Except
-import Control.Monad
+import Language.Jass.TestUtils
+import Control.Applicative
+import Control.Monad.IO.Class
 
 import Test.Tasty
 import Test.Tasty.HUnit
+
+import Foreign.C.String
+import Foreign.C.Types
+import Foreign.Ptr
 
 type NativeWriteln = CString -> IO ()
 nativeWriteln :: NativeWriteln
 nativeWriteln adr = putStrLn =<< fromJass adr
 foreign import ccall "wrapper" mkNativeWriteln :: NativeWriteln -> IO (FunPtr NativeWriteln)
 
+type NativeI2S = CInt -> IO CString
+nativeI2S :: NativeI2S
+nativeI2S i = toJass.show =<< fromJass i
+foreign import ccall "wrapper" mkNativeI2S :: NativeI2S -> IO (FunPtr NativeI2S)
+
 makeNativeTable :: NativeTableMaker
-makeNativeTable _ = liftIO $ sequence [("writeln",) . castFunPtr <$> mkNativeWriteln nativeWriteln]
+makeNativeTable _ = liftIO $ sequence [ ("writeln",) . castFunPtr <$> mkNativeWriteln nativeWriteln
+                                      , ("I2S",) . castFunPtr <$> mkNativeI2S nativeI2S ]
 
 checkJassFolder :: FilePath -> NativeTableMaker -> Assertion
-checkJassFolder folder natives = return ()
+checkJassFolder folder natives = assertExcept $ do
+  prog <- constructProgramFromSource folder "main.j"
+  executeProgram prog natives callMain
 
 multifileTests :: TestTree
-multifileTests = let dbgFlag = False in testGroup "jass helloworld"
+multifileTests = testGroup "multifile helloworld"
   [ testCase "hello.j" $ checkJassFolder "tests/multifile" makeNativeTable
   ]

--- a/test-suites/Language/Jass/Parser/GrammarTest.hs
+++ b/test-suites/Language/Jass/Parser/GrammarTest.hs
@@ -66,7 +66,7 @@ nosrc = SrcPos "" 0 0
 
 simpleParsing :: TestTree
 simpleParsing = testGroup "hello world parsing"
-  [ testCase "hello world" $ testJassFile' "tests/hello.j" (JassModule nosrc [] [] [
+  [ testCase "hello world" $ testJassFile' "tests/hello.j" (JassModule nosrc [] [] [] [
       NativeDecl nosrc False (FunctionDecl nosrc "writeln" [Parameter nosrc JString "msg"] Nothing)
     ] [
       Function nosrc False (FunctionDecl nosrc "main" [] Nothing) [] [
@@ -77,12 +77,12 @@ simpleParsing = testGroup "hello world parsing"
   
 syntaxTests :: TestTree
 syntaxTests = testGroup "Syntax tests"
-    [ testCase "empty module" $ parseTestModule "" (JassModule nosrc [] [] [] []),
+    [ testCase "empty module" $ parseTestModule "" (JassModule nosrc [] [] [] [] []),
       testCase "Type declarations" $
         parseTestModule
             ("type widget extends handle\n" ++
             "type destructable extends widget")
-            (JassModule nosrc [
+            (JassModule nosrc [] [
                 TypeDef nosrc "widget" JHandle,
                 TypeDef nosrc "destructable" (JUserDefined "widget")
             ] [] [] []),
@@ -112,7 +112,7 @@ syntaxTests = testGroup "Syntax tests"
               "constant real      bj_PI                            = 3.14159\n" ++
               "force              bj_FORCE_ALL_PLAYERS        = null\n" ++
            "endglobals")
-          (JassModule nosrc [] [
+          (JassModule nosrc [] [] [
             GlobalVar nosrc False False JReal "global1" Nothing,
             GlobalVar nosrc False False JInteger "global2" (Just $ IntegerLiteral nosrc 0),
             GlobalVar nosrc True False JReal "global3" (Just $ RealLiteral nosrc 3.14),
@@ -129,7 +129,7 @@ syntaxTests = testGroup "Syntax tests"
            "native function2 takes nothing returns widget\n" ++
            "native function3 takes integer par1, code par2 returns handle\n" ++
            "constant native function4 takes nothing returns nothing")
-          (JassModule nosrc [] [] [
+          (JassModule nosrc [] [] [] [
               NativeDecl nosrc False (FunctionDecl nosrc "function1" [] Nothing),
               NativeDecl nosrc False (FunctionDecl nosrc "function2" [] (Just $ JUserDefined "widget")),
               NativeDecl nosrc False (FunctionDecl nosrc "function3" [
@@ -141,35 +141,35 @@ syntaxTests = testGroup "Syntax tests"
         parseTestModule
             ("function simple takes nothing returns nothing\n" ++
              "endfunction")
-            (JassModule nosrc [] [] [] [
+            (JassModule nosrc [] [] [] [] [
                 Function nosrc False (FunctionDecl nosrc "simple" [] Nothing) [] []
             ]),
       testCase "constant function" $
         parseTestModule
             ("constant function simple takes nothing returns nothing\n" ++
              "endfunction")
-            (JassModule nosrc [] [] [] [
+            (JassModule nosrc [][] [] [] [
                 Function nosrc True (FunctionDecl nosrc "simple" [] Nothing) [] []
             ]),
       testCase "function with return type" $
         parseTestModule
             ("function simple takes nothing returns widget\n" ++
              "endfunction")
-            (JassModule nosrc [] [] [] [
+            (JassModule nosrc [] [] [] [] [
                 Function nosrc False (FunctionDecl nosrc "simple" [] (Just (JUserDefined "widget"))) [] []
             ]),
       testCase "function with parameters" $
         parseTestModule
             ("function simple takes integer par1, real par2, handle par3 returns nothing\n" ++
              "endfunction")
-            (JassModule nosrc [] [] [] [
+            (JassModule nosrc [] [] [] [] [
                 Function nosrc False (FunctionDecl nosrc "simple" [Parameter nosrc JInteger "par1", Parameter nosrc JReal "par2", Parameter nosrc JHandle "par3"] Nothing) [] []
             ]),
       testCase "function with parameters" $
         parseTestModule
             ("function simple takes widget par1, location par2, handle par3 returns nothing\n" ++
              "endfunction")
-            (JassModule nosrc [] [] [] [
+            (JassModule nosrc [] [] [] [] [
                 Function nosrc False (FunctionDecl nosrc "simple" [
                   Parameter nosrc (JUserDefined "widget") "par1", 
                   Parameter nosrc (JUserDefined "location") "par2", 

--- a/test-suites/Language/Jass/Semantic/CheckTest.hs
+++ b/test-suites/Language/Jass/Semantic/CheckTest.hs
@@ -14,7 +14,7 @@ checkJassFile path = do
   res <- parseJassFile path
   case res of
     Left err -> assertFailure (show err)
-    Right tree -> case checkModuleSemantic tree of
+    Right tree -> case checkModuleSemantic' tree of
       Left err -> assertFailure (show err)
       Right _ -> return ()
 
@@ -24,7 +24,7 @@ checkJassFiles paths = do
   trees <- forM reses $ \res -> case res of
     Left err -> assertFailure (show err) >> return undefined
     Right tree -> return tree
-  case checkModulesSemantic trees of
+  case checkModulesSemantic' trees of
     Left err -> assertFailure (show err)
     Right _ -> return ()
           

--- a/test-suites/Language/Jass/TestUtils.hs
+++ b/test-suites/Language/Jass/TestUtils.hs
@@ -1,0 +1,16 @@
+module Language.Jass.TestUtils(
+    assertExcept
+  , module Utils
+  ) where
+  
+import Control.Monad.Trans.Except
+import Language.Jass.Utils as Utils
+import Test.Tasty.HUnit
+
+-- | Helps testing ExceptT 
+assertExcept :: Show e => ExceptT e IO a -> Assertion
+assertExcept action = do
+  res <- runExceptT action
+  case res of
+    Left err -> assertFailure $ show err
+    Right _ -> return ()

--- a/test-suites/all-tests.hs
+++ b/test-suites/all-tests.hs
@@ -3,6 +3,7 @@ module Main where
 import Language.Jass.Parser.GrammarTest
 import Language.Jass.Semantic.CheckTest
 import Language.Jass.Codegen.GeneratorTest
+import Language.Jass.Codegen.MultiFileTest
 
 import Test.Tasty
 --import Test.Tasty.QuickCheck as QC
@@ -15,5 +16,6 @@ tests :: TestTree
 tests = testGroup "Tests" [
   testGroup "Parsing" [syntaxTests, simpleParsing, commonParsing],
   testGroup "Semantic checks" [commonSemanticTest],
-  testGroup "Code generation" [simpleCodegenTest]
+  testGroup "Code generation" [simpleCodegenTest],
+  testGroup "Integration tests" [multifileTests]
   ]

--- a/tests/multifile/main.j
+++ b/tests/multifile/main.j
@@ -1,0 +1,6 @@
+import mylib
+
+function main takes nothing returns nothing
+	call writeln(SOME_CONSTANT)
+	call writeln(square(42))
+endfunction

--- a/tests/multifile/main.j
+++ b/tests/multifile/main.j
@@ -1,6 +1,6 @@
 import mylib
 
 function main takes nothing returns nothing
-	call writeln(SOME_CONSTANT)
-	call writeln(square(42))
+	call writeln(I2S(SOME_CONSTANT))
+	call writeln(I2S(square(42)))
 endfunction

--- a/tests/multifile/mylib.j
+++ b/tests/multifile/mylib.j
@@ -1,0 +1,9 @@
+globals
+	constant int SOME_CONSTANT = 42
+endglobals
+
+native writeln takes string msg returns nothing
+
+function square takes integer n returns integer
+	return n*n
+endfunction

--- a/tests/multifile/mylib.j
+++ b/tests/multifile/mylib.j
@@ -1,8 +1,9 @@
 globals
-	constant int SOME_CONSTANT = 42
+	constant integer SOME_CONSTANT = 42
 endglobals
 
 native writeln takes string msg returns nothing
+native I2S takes integer i returns string
 
 function square takes integer n returns integer
 	return n*n


### PR DESCRIPTION
Multifile support, now can compile, link and execute jass programs spared within several modules.
- Change ot grammar: keyword `import`:

```
import my.favorite.package.module // will import my/favorite/package/module.j file
```
